### PR TITLE
fix handleAppCameToForeground

### DIFF
--- a/architecture/kmm-tagd-android/src/main/java/io/tagd/android/app/AppForegroundBackgroundObserver.kt
+++ b/architecture/kmm-tagd-android/src/main/java/io/tagd/android/app/AppForegroundBackgroundObserver.kt
@@ -59,14 +59,15 @@ open class AppForegroundBackgroundObserver(
     }
 
     private fun handleAppCameToForeground() {
-        if (backgroundSince == 0L ||
-            (backgroundSince > 0L &&
-                    System.currentTimeMillis() - backgroundSince > backgroundTimeMs)
-        ) {
+        val wasInBackground = backgroundSince >= 0L && System.currentTimeMillis() > backgroundSince
+        if (wasInBackground) {
+            val timeSpentInBackground = System.currentTimeMillis() - backgroundSince
 
+            if (timeSpentInBackground > backgroundTimeMs) {
+                app?.onForeground()
+            }
             removeWatcher()
             backgroundSince = -1L
-            app?.onForeground()
         }
     }
 


### PR DESCRIPTION
## Bug Description:
`AppForegroundBackground` marks the app in background even if app went through any configuration change which causes the onStop..onDestroy to onCreate..onStart calls. 
Since the time spent in this case is less than `backgroundTimeMs (i.e acceptable time duration required to mark app in background`, the observer should not mark app in background. That's the bug 1, improper onBackground state.
It is following by series of other bugs in which foreground is also not mark properly when required

## Bug Fix:
`handleAppCameToForeground` now removes the Runnable which was causing onBackground for the app.