### PR TITLE
fix BindableSubject and its notify calls

### DIFF
--- a/architecture/kmm-tagd-android/src/main/java/io/tagd/android/widget/BindableRecyclerViewHolder.kt
+++ b/architecture/kmm-tagd-android/src/main/java/io/tagd/android/widget/BindableRecyclerViewHolder.kt
@@ -125,8 +125,11 @@ abstract class BindableRecyclerViewHolder<T : DataObject, V : BindableView<T>, B
 
     override fun release() {
         unbind()
+
         binder?.onDestroy()
         binder = null
+
+        model?.remove(this)
         model = null
     }
 }

--- a/architecture/kmm-tagd-arch/src/commonMain/kotlin/io/tagd/arch/data/bind/BindableSubject.kt
+++ b/architecture/kmm-tagd-arch/src/commonMain/kotlin/io/tagd/arch/data/bind/BindableSubject.kt
@@ -78,7 +78,7 @@ open class BindableSubject : Initializable, Serializable, AsyncContext {
     protected fun ObserveOn?.notifyObservers(context: AsyncContext = this@BindableSubject) {
         this?.invoke(context, 0) {
             notifyBindables()
-        } ?: {
+        } ?: kotlin.run {
             notifyBindables()
         }
     }


### PR DESCRIPTION
## Bug Description 1 :
In the following previous code sample, the notifyBindables is not called when `this` (ObserveOn) is null. This is because the block after the elvis operator is treated as lamda and never executed.  
```    
    protected fun ObserveOn?.notifyObservers(context: AsyncContext = this@BindableSubject) {
        this?.invoke(context, 0) {
            notifyBindables()
        } ?: {
            notifyBindables()
        }
    }
```
Fixed using `kotlin.run {}`
## Bug Description 2 :
The  `BindableRecyclerViewHolder` added in any `BindableSubject` was never removed.
Fix: In the release call it is now being safely removed