### PR TITLE
resolve app launch bugs and crashes

### DIFF
--- a/architecture/kmm-tagd-android/src/main/java/io/tagd/android/app/ActivityLifeCycleObserver.kt
+++ b/architecture/kmm-tagd-android/src/main/java/io/tagd/android/app/ActivityLifeCycleObserver.kt
@@ -25,6 +25,8 @@ import java.lang.ref.WeakReference
 open class ActivityLifeCycleObserver(application: TagdApplication) :
     Application.ActivityLifecycleCallbacks, ComponentLifeCycleObserver<Activity> {
 
+    private var awaitingToLaunch: Boolean = true
+
     private var appReference: WeakReference<TagdApplication>? = WeakReference(application)
     protected val app: TagdApplication?
         get() = appReference?.get()
@@ -45,10 +47,15 @@ open class ActivityLifeCycleObserver(application: TagdApplication) :
 
     override fun onActivityPreCreated(activity: Activity, savedInstanceState: Bundle?) {
         super.onActivityPreCreated(activity, savedInstanceState)
+        awaitingToLaunch = false
         setupAppLauncher(activity, savedInstanceState)
     }
 
     override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
+        if (awaitingToLaunch) {
+            awaitingToLaunch = false
+            setupAppLauncher(activity, savedInstanceState)
+        }
         setPreviousAndCurrent(activity)
     }
 

--- a/architecture/kmm-tagd-android/src/main/java/io/tagd/android/app/FragmentActivity.kt
+++ b/architecture/kmm-tagd-android/src/main/java/io/tagd/android/app/FragmentActivity.kt
@@ -35,7 +35,7 @@ abstract class FragmentActivity : androidx.fragment.app.FragmentActivity(),
 
     private fun getOrNewLifecycleFreeState() =
         supportFragmentManager.findFragmentByTag(HeadLessFragment.TAG) as? HeadLessFragment
-            ?: HeadLessFragment(this)
+            ?: HeadLessFragment.new(this)
 
     protected open fun interceptOnCreate(savedInstanceState: Bundle?) {
         // no-op
@@ -84,6 +84,7 @@ abstract class FragmentActivity : androidx.fragment.app.FragmentActivity(),
 
     override fun onDestroy() {
         awaitReadyLifeCycleEventsDispatcher().unregister(this)
+        lifecycleFreeState = null
         super.onDestroy()
     }
 
@@ -104,19 +105,26 @@ abstract class FragmentActivity : androidx.fragment.app.FragmentActivity(),
     }
 }
 
-class HeadLessFragment(activity: FragmentActivity) : Fragment() {
+class HeadLessFragment : Fragment() {
 
     var triggerInject: Boolean = true
 
     init {
         retainInstance = true //since this activity is not just for ViewModels then deprecation doesn't make sense
-        activity.supportFragmentManager.beginTransaction().add(
-            this,
-            TAG
-        ).commitNow()
     }
 
     companion object {
         const val TAG = "head-less"
+
+        @JvmStatic
+        fun new(activity: FragmentActivity): HeadLessFragment {
+            val fragment = HeadLessFragment()
+            activity.supportFragmentManager
+                .beginTransaction()
+                .add(fragment, TAG)
+                .commitNow()
+
+            return fragment
+        }
     }
 }

--- a/architecture/kmm-tagd-core/src/commonMain/kotlin/io/tagd/core/State.kt
+++ b/architecture/kmm-tagd-core/src/commonMain/kotlin/io/tagd/core/State.kt
@@ -38,7 +38,7 @@ open class State : Releasable {
      */
     @Suppress("UNCHECKED_CAST")
     fun <T> get(key: String): T? {
-        return map[key] as T?
+        return map[key] as? T?
     }
 
     /**


### PR DESCRIPTION
Following are the issues resolved:
## 1. Crash when activity is re created and _don't keep activities_ is ON
**Reason**: System was unable to re-create instance of `HeadLessFragment` because of parameterised constructor.
**Fix**: Provided `HeadLessFragment` with an empty Constructor,  and restructure its instance creation logic.
## 2. Activity State is never onReady for API below 28
**Reason**: `onActivityPreCreated` was never called in those below API levels which was responsible to setupAppLauncher and further flow.
**Fix**: invoke `setupAppLauncher` inside `onActivityCreated` if it was not called in `onActivityPreCreated` by maintaining a boolean state
## 3. Unsafe TypeCast in `State.kt`
**Changed**: `map[key] as T?` to `map[key] as? T?`  (as?)